### PR TITLE
fix compilation for ESP32 microcontroller

### DIFF
--- a/src/cn-cbor/cn-cbor.h
+++ b/src/cn-cbor/cn-cbor.h
@@ -18,8 +18,10 @@ extern "C" {
 #include <stdint.h>
 #include <unistd.h>
 
+#ifndef ESP32
 /* missing in arduino headers */
 typedef long ssize_t;
+#endif
 
 /**
  * All of the different kinds of CBOR values.

--- a/src/cn-cbor/cn-encoder.c
+++ b/src/cn-cbor/cn-encoder.c
@@ -12,6 +12,10 @@ extern "C" {
 #include <stdbool.h>
 #include <assert.h>
 
+#ifdef ESP32
+#include <lwip/def.h> // for htons() and htonl()
+#endif
+
 #include "cn-cbor/cn-cbor.h"
 #include "cbor.h"
 


### PR DESCRIPTION
This change allows the library to compile and work on the ESP32 microcontroller via ESP32 Arduino core.