### PR TITLE
Rewrite hton*p and ntoh*p in endian-agnostic fashion

### DIFF
--- a/examples/simple/simple.ino
+++ b/examples/simple/simple.ino
@@ -11,27 +11,38 @@ void setup() {
 
 void loop() {
   CborBuffer buffer(200);
-  CborObject object = CborObject(buffer);
 
+  CborObject object(buffer);
   object.set("string", "value");
   object.set("integer", -1234);
-  
-  CborObject child = CborObject(buffer);
+
+  CborObject child(buffer);
   child.set("key", "value");
   object.set("object", child);
-  
-  CborArray array = CborArray(buffer);
-  array.add(-1234);
+
+  CborArray array(buffer);
+  array.add(4321);
   object.set("array", array);
 
+  uint8_t encoded[200];
+  size_t len = object.encode(encoded, sizeof(encoded));
+  Serial.print("encoded length: ");
+  Serial.println(len);
+
+  CborVariant decoded = buffer.decode(encoded, len);
+  CborObject obj = decoded.asObject();
+
   Serial.print("string value: ");
-  Serial.println(object.get("string").asString());
+  Serial.println(obj.get("string").asString());
 
   Serial.print("integer value: ");
-  Serial.println(object.get("integer").asInteger());
+  Serial.println(obj.get("integer").asInteger());
 
   Serial.print("child string value: ");
-  Serial.println(object.get("object").asObject().get("key").asString());
+  Serial.println(obj.get("object").asObject().get("key").asString());
+
+  Serial.print("array integer value: ");
+  Serial.println(obj.get("array").asArray().get(0).asInteger());
 
   delay(1000);
 }


### PR DESCRIPTION
This allows encoding/decoding functions to compile and work on
platforms without htons and htonl functions, such as Adafruit nRF52
and Arduino Uno.