### PR TITLE
fix: release cn_cbor mem in destructor

### DIFF
--- a/src/CborObject.cpp
+++ b/src/CborObject.cpp
@@ -10,6 +10,14 @@ CborObject::CborObject(CborBuffer& buffer, cn_cbor* raw) : buffer(buffer) {
   }
 }
 
+CborObject::~CborObject() {
+  if (raw->parent == 0) {
+    cn_cbor_free(this->raw, &buffer.context);
+  }
+
+  this->raw = 0;
+}
+
 CborVariant CborObject::get(const char* key) {
   return CborVariant(buffer, cn_cbor_mapget_string(raw, key));
 }

--- a/src/CborObject.h
+++ b/src/CborObject.h
@@ -8,6 +8,7 @@ class CborObject {
 
  public:
   CborObject(CborBuffer& buffer, cn_cbor* raw=0);
+  ~CborObject();
 
   CborVariant get(const char* key);
 


### PR DESCRIPTION
Release the memory when the destructor of the root object is called.

The following example code can be used to reproduce the problem and the fix on a ESP32 board:

```cpp
#include <ArduinoCbor.h>

void setup() {
  Serial.begin(115200);

  while(!Serial) {
    delay(10);
  }
}

void loop() {
  CborBuffer buffer(200);

  CborObject object(buffer);
  object.set("string", "value");
  object.set("integer", -1234);

  CborObject child(buffer);
  child.set("key", "value");
  object.set("object", child);

  CborArray array(buffer);
  array.add(4321);
  object.set("array", array);

  uint8_t encoded[200];
  size_t len = object.encode(encoded, sizeof(encoded));
  Serial.print("encoded length: ");
  Serial.println(len);

  CborVariant decoded = buffer.decode(encoded, len);
  CborObject obj = decoded.asObject();

  Serial.print("string value: ");
  Serial.println(obj.get("string").asString());

  Serial.print("integer value: ");
  Serial.println(obj.get("integer").asInteger());

  Serial.print("child string value: ");
  Serial.println(obj.get("object").asObject().get("key").asString());

  Serial.print("array integer value: ");
  Serial.println(obj.get("array").asArray().get(0).asInteger());

  Serial.print("Current free heap: ");
  Serial.println(esp_get_free_heap_size());

  delay(1000);
}
```

fixes #5 